### PR TITLE
Browser back/forward navigation in Explore.

### DIFF
--- a/components/explore/component.jsx
+++ b/components/explore/component.jsx
@@ -4,13 +4,11 @@ import ExploreMap from 'components/explore/map';
 import ExploreSidebar from 'components/explore/sidebar';
 import Autocomplete from 'components/autocomplete';
 import Button from 'components/button';
-import Url from 'components/url';
 
 export default function Explore({
   locations,
   activeLocationId,
   embed,
-  urlParams,
   setGeometryId,
   setGeometryValues,
 }) {
@@ -18,14 +16,12 @@ export default function Explore({
     locations: PropTypes.array,
     activeLocationId: PropTypes.string,
     embed: PropTypes.bool,
-    urlParams: PropTypes.object,
     setGeometryId: PropTypes.func,
     setGeometryValues: PropTypes.func,
   };
 
   return (
     <div className="c-explore">
-      <Url queryParams={urlParams} />
       {!embed && (
         <div className="explore-search wrapper">
           <Autocomplete

--- a/components/explore/sidebar/sidebar-card/component.jsx
+++ b/components/explore/sidebar/sidebar-card/component.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import startCase from 'lodash.startcase';
 import Icon from 'components/icon';
@@ -6,9 +7,11 @@ import HazardIndicator from 'components/explore/hazard-indicator';
 import ArrowUp from 'svgs/arrow_up.svg?sprite';
 import { CATEGORIES } from 'providers/indicators/constants';
 
+// eslint-disable-next-line import/no-cycle
+import Card from './index';
 import styles from './styles.module.scss';
 
-export default function sidebarCard({
+function SidebarCard({
   item,
   modalFunctions,
   icons,
@@ -20,6 +23,7 @@ export default function sidebarCard({
   currentLocation,
   childrenDistribution,
   toggleIndicatorsActive,
+  isChildrenCard,
 }) {
   const { openModal, setModalContent } = modalFunctions;
   const isItemActive = !!active.find((a) => a === item.id);
@@ -29,6 +33,7 @@ export default function sidebarCard({
   const showBtnDisabled =
     (active.length > 1 || activeCategories.includes(item.category.id)) &&
     !isItemActive;
+  const [subLayersVisible, showSubLayers] = useState(false);
 
   // CHART DATA
   const [chartVisible, showChart] = useState(false);
@@ -53,102 +58,158 @@ export default function sidebarCard({
 
   return (
     <li className={styles.sidebarCard}>
-      <div className={styles.cardHeader}>
-        <div className={styles.cardTitle}>
-          <div className={styles.category}>
-            <Icon
-              className={styles.categoryIcon}
-              icon={icons[item.category.name]}
-              style={{ fill: colors[item.category.name] }}
-            />
-            <span className={styles.categoryName}>{item.category.name}</span>
+      <div
+        className={styles.cardBody}
+        style={
+          isChildrenCard && {
+            borderLeft: `5px solid ${colors[item.category.name]}`,
+          }
+        }
+      >
+        <div className={styles.cardHeader}>
+          <div className={styles.cardTitle}>
+            <div className={styles.category}>
+              <Icon
+                className={styles.categoryIcon}
+                icon={icons[item.category.name]}
+                style={{ fill: colors[item.category.name] }}
+              />
+              <span className={styles.categoryName}>{item.category.name}</span>
+            </div>
+            <span className={styles.indicatorName}>{startCase(item.name)}</span>
           </div>
-          <span className={styles.indicatorName}>{startCase(item.name)}</span>
+
+          <div className={styles.topControls}>
+            {chartData && (
+              <button
+                className={styles.toggleChart}
+                onClick={() => showChart(!chartVisible)}
+                style={{ transform: `rotate(${chartVisible ? 0 : 180}deg)` }}
+              >
+                <Icon icon={ArrowUp} />
+              </button>
+            )}
+            {geometryValues.length > 0 && (
+              <HazardIndicator
+                hazardLevel={indicatorValues ? indicatorValues.hazardValue : 5}
+                className={styles.hazard}
+              />
+            )}
+          </div>
         </div>
 
-        <div className={styles.topControls}>
-          {chartData && (
+        {chartVisible && chartData && (
+          <div className={styles.chartModule}>
+            <p className={styles.chartText}>
+              {`${currentLocation.label} ${startCase(
+                item.name
+              )} Distribution by county:`}
+            </p>
+            <div className={styles.chartWrapper}>
+              {chartData &&
+                Object.entries(chartData).map(([hazardLevel, count]) => (
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${(count / geometryChildren.length) * 100}%`,
+                      backgroundColor: chartRamp[hazardLevel],
+                    }}
+                  />
+                ))}
+            </div>
+            <div className={styles.chartLegend}>
+              <span>{chartLegendValues.low}</span>
+              <span>{chartLegendValues.high}</span>
+            </div>
+          </div>
+        )}
+
+        <div className={styles.cardFooterControls}>
+          <div>
             <button
-              className={styles.toggleChart}
-              onClick={() => showChart(!chartVisible)}
-              style={{ transform: `rotate(${chartVisible ? 0 : 180}deg)` }}
+              className={styles.controlButton}
+              onClick={() => {
+                openModal(true);
+                setModalContent(item);
+              }}
+              disabled={!item.description}
+              title={
+                item.description
+                  ? 'MORE INFORMATION ABOUT THIS INDICATOR'
+                  : "THERE'S NO AVAILABLE INFORMATION"
+              }
             >
-              <Icon icon={ArrowUp} />
+              More Info
             </button>
-          )}
-          {geometryValues.length > 0 && (
-            <HazardIndicator
-              hazardLevel={indicatorValues ? indicatorValues.hazardValue : 5}
-              className={styles.hazard}
-            />
-          )}
+            {item.children && item.children.length > 0 && (
+              <button
+                className={cx(styles.controlButton, styles['--wide'], {
+                  [styles['--active']]: subLayersVisible,
+                })}
+                onClick={() => {
+                  showSubLayers(!subLayersVisible);
+                }}
+                style={{
+                  backgroundColor:
+                    subLayersVisible && colors[item.category.name],
+                }}
+              >
+                {subLayersVisible ? 'Close sub-layers' : 'Open sub-layers'}
+              </button>
+            )}
+            <button
+              className={cx(styles.controlButton, {
+                [styles['--active']]: isItemActive,
+              })}
+              onClick={() => {
+                toggleIndicatorsActive(item.id);
+              }}
+              disabled={showBtnDisabled}
+              title={
+                showBtnDisabled
+                  ? 'YOU CAN CHOOSE UP TO TWO LAYERS'
+                  : 'SEE THIS INDICATOR ON THE MAP'
+              }
+              style={{
+                backgroundColor: isItemActive && colors[item.category.name],
+              }}
+            >
+              {isItemActive ? 'Hide Layer' : 'Show layer'}
+            </button>
+          </div>
         </div>
       </div>
 
-      {chartVisible && chartData && (
-        <div className={styles.chartModule}>
-          <p className={styles.chartText}>
-            {`${currentLocation.label} ${startCase(
-              item.name
-            )} Distribution by county:`}
-          </p>
-          <div className={styles.chartWrapper}>
-            {chartData &&
-              Object.entries(chartData).map(([hazardLevel, count]) => (
-                <div
-                  style={{
-                    height: '100%',
-                    width: `${(count / geometryChildren.length) * 100}%`,
-                    backgroundColor: chartRamp[hazardLevel],
-                  }}
-                />
-              ))}
-          </div>
-          <div className={styles.chartLegend}>
-            <span>{chartLegendValues.low}</span>
-            <span>{chartLegendValues.high}</span>
-          </div>
-        </div>
-      )}
-
-      <div className={styles.cardFooterControls}>
-        <div>
-          <button
-            className={styles.controlButton}
-            onClick={() => {
-              openModal(true);
-              setModalContent(item);
-            }}
-            disabled={!item.description}
-            title={
-              item.description
-                ? 'MORE INFORMATION ABOUT THIS INDICATOR'
-                : "THERE'S NO AVAILABLE INFORMATION"
-            }
-          >
-            More Info
-          </button>
-          <button
-            className={cx(styles.controlButton, {
-              [styles['--active']]: isItemActive,
-            })}
-            onClick={() => {
-              toggleIndicatorsActive(item.id);
-            }}
-            disabled={showBtnDisabled}
-            title={
-              showBtnDisabled
-                ? 'YOU CAN CHOOSE UP TO TWO LAYERS'
-                : 'SEE THIS INDICATOR ON THE MAP'
-            }
-            style={{
-              backgroundColor: isItemActive && colors[item.category.name],
-            }}
-          >
-            {isItemActive ? 'Hide Layer' : 'Show layer'}
-          </button>
-        </div>
-      </div>
+      {subLayersVisible &&
+        item.children &&
+        item.children.map((d) => (
+          // recursive SidebarCard
+          <Card
+            item={d}
+            key={d.id}
+            modalFunctions={modalFunctions}
+            icons={icons}
+            colors={colors}
+            isChildrenCard
+          />
+        ))}
     </li>
   );
 }
+
+SidebarCard.propTypes = {
+  item: PropTypes.object,
+  modalFunctions: PropTypes.object,
+  icons: PropTypes.array,
+  colors: PropTypes.array,
+  active: PropTypes.array, // active indicators
+  activeCategories: PropTypes.array,
+  geometryValues: PropTypes.array,
+  geometryChildren: PropTypes.array,
+  currentLocation: PropTypes.object,
+  childrenDistribution: PropTypes.object,
+  toggleIndicatorsActive: PropTypes.func,
+  isChildrenCard: PropTypes.bool,
+};
+
+export default SidebarCard;

--- a/components/explore/sidebar/sidebar-card/styles.module.scss
+++ b/components/explore/sidebar/sidebar-card/styles.module.scss
@@ -2,14 +2,13 @@
 @import "styles/utils";
 
 .sidebarCard {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  min-height: rem(100px);
-
   .cardBody {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
     background: $color-white;
     margin: 0 0 calc(#{$space-1} / 2);
+    min-height: rem(110px);
     padding: $space-1 * 2 $space-1 $space-1 $space-1 * 4; // 12 6 6 24
 
     .cardHeader {

--- a/components/explore/sidebar/sidebar-card/styles.module.scss
+++ b/components/explore/sidebar/sidebar-card/styles.module.scss
@@ -2,130 +2,138 @@
 @import "styles/utils";
 
 .sidebarCard {
-  background: $color-white;
-  margin: 0 0 calc(#{$space-1} / 2);
-  padding: $space-1 * 2 $space-1 $space-1 $space-1 * 4; // 12 6 6 24
-  min-height: rem(100px);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  min-height: rem(100px);
 
-  .cardHeader {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+  .cardBody {
+    background: $color-white;
+    margin: 0 0 calc(#{$space-1} / 2);
+    padding: $space-1 * 2 $space-1 $space-1 $space-1 * 4; // 12 6 6 24
 
-    .cardTitle {
-      color: $color-1;
+    .cardHeader {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
 
-      .category {
-        display: flex;
-        align-items: center;
-        margin-bottom: rem(8px);
+      .cardTitle {
+        color: $color-1;
 
-        .categoryIcon {
-          height: 20px;
-          width: 20px;
-          margin-right: rem(12px);
+        .category {
+          display: flex;
+          align-items: center;
+          margin-bottom: rem(8px);
+
+          .categoryIcon {
+            height: 20px;
+            width: 20px;
+            margin-right: rem(12px);
+          }
+
+          .categoryName {
+            font-family: $font-sans;
+            font-size: 10px;
+            font-weight: 500;
+            letter-spacing: 0.71px;
+            line-height: 13px;
+            text-transform: uppercase;
+          }
         }
 
-        .categoryName {
-          font-family: $font-sans;
+        .indicatorName {
+          display: inline-block;
+          max-width: 240px;
+          font-family: $font-serif;
+          font-size: 18px;
+          line-height: 22px;
+        }
+      }
+
+      .topControls {
+        display: flex;
+        flex-direction: row-reverse;
+        margin-right: $space-1 * 3;
+
+        .hazard {
+          width: 140px;
+          margin: 0 auto;
+        }
+
+        .toggleChart {
+          height: 14px;
+          margin-left: 16px;
+
+          svg {
+            width: 14px;
+          }
+        }
+      }
+    }
+
+    .chartModule {
+      margin: 20px 0;
+      color: $color-1;
+      font-family: $font-sans;
+
+      .chartText {
+        font-size: 14px;
+        letter-spacing: 0;
+        line-height: 30px;
+      }
+
+      .chartWrapper {
+        display: flex;
+        height: 28px;
+        margin: 5px 0 12px;
+      }
+
+      .chartLegend {
+        display: flex;
+        justify-content: space-between;
+
+        span {
           font-size: 10px;
-          font-weight: 500;
+          font-weight: 400;
           letter-spacing: 0.71px;
           line-height: 13px;
           text-transform: uppercase;
         }
       }
-
-      .indicatorName {
-        display: inline-block;
-        max-width: 240px;
-        font-family: $font-serif;
-        font-size: 18px;
-        line-height: 22px;
-      }
     }
 
-    .topControls {
+    .cardFooterControls {
       display: flex;
-      flex-direction: row-reverse;
-      margin-right: $space-1 * 3;
+      justify-content: flex-end;
 
-      .hazard {
-        width: 140px;
-        margin: 0 auto;
-      }
-
-      .toggleChart {
-        height: 14px;
-        margin-left: 16px;
-
-        svg {
-          width: 14px;
-        }
-      }
-    }
-  }
-
-  .chartModule {
-    margin: 20px 0;
-    color: $color-1;
-    font-family: $font-sans;
-
-    .chartText {
-      font-size: 14px;
-      letter-spacing: 0;
-      line-height: 30px;
-    }
-
-    .chartWrapper {
-      display: flex;
-      height: 28px;
-      margin: 5px 0 12px;
-    }
-
-    .chartLegend {
-      display: flex;
-      justify-content: space-between;
-
-      span {
+      .controlButton {
+        height: rem(28px);
+        width: rem(95px);
+        border: 1px solid adjust-color($color: $color-1, $alpha: -0.7);
+        margin-left: 4px;
+        color: $color-1;
+        font-family: $font-sans;
         font-size: 10px;
-        font-weight: 400;
+        font-weight: 500;
+        text-transform: uppercase;
         letter-spacing: 0.71px;
         line-height: 13px;
-        text-transform: uppercase;
-      }
-    }
-  }
 
-  .cardFooterControls {
-    display: flex;
-    justify-content: flex-end;
+        &.--active {
+          color: $color-white;
+          border: 1px solid transparent;
+        }
 
-    .controlButton {
-      height: rem(28px);
-      width: (95px);
-      border: 1px solid adjust-color($color: $color-1, $alpha: -0.7);
-      margin-left: 4px;
-      color: $color-1;
-      font-family: $font-sans;
-      font-size: 10px;
-      font-weight: 500;
-      text-transform: uppercase;
-      letter-spacing: 0.71px;
-      line-height: 13px;
+        &.--wide {
+          width: auto;
+          padding: 0 12px;
+        }
 
-      &.--active {
-        color: $color-white;
-        border: 1px solid transparent;
-      }
-
-      &:disabled {
-        color: adjust-color($color: $color-1, $alpha: -0.7);
-        border: 1px solid adjust-color($color: $color-1, $alpha: -0.9);
-        cursor: not-allowed;
+        &:disabled {
+          color: adjust-color($color: $color-1, $alpha: -0.7);
+          border: 1px solid adjust-color($color: $color-1, $alpha: -0.9);
+          cursor: not-allowed;
+        }
       }
     }
   }

--- a/components/url/component.jsx
+++ b/components/url/component.jsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import qs from 'query-string';
 import useDeepCompareEffect from 'utils/deepCompare';
 import isEmpty from 'lodash.isempty';
+import { diff } from 'utils/diff';
 
 export default function URL({
   type = 'push',
@@ -16,6 +17,7 @@ export default function URL({
 }) {
   const router = useRouter();
   const isMounted = useRef(false);
+  const prevQuery = useRef({});
   const { query, pathname } = router;
 
   useDeepCompareEffect(() => {
@@ -33,13 +35,19 @@ export default function URL({
   useDeepCompareEffect(() => {
     if (isMounted.current && !isEmpty(query)) {
       const queryKeys = Object.keys(queryParams);
+      const changedKeys = Object.keys(diff(query, prevQuery.current));
+      console.log(changedKeys, query, prevQuery.current);
 
       queryKeys.forEach((k) => {
-        if (queryFunction) queryFunction({ key: k, value: query[k] || null });
+        if (queryFunction && changedKeys.includes(k)) {
+          queryFunction({ key: k, value: query[k] || null });
+        }
       });
     } else {
       isMounted.current = true;
     }
+
+    prevQuery.current = query;
   }, [query]);
 
   return null;

--- a/components/url/component.jsx
+++ b/components/url/component.jsx
@@ -1,9 +1,13 @@
-import { useEffect } from 'react';
+import { useRef } from 'react';
 import { useRouter } from 'next/router';
 import qs from 'query-string';
+import useDeepCompareEffect from 'utils/deepCompare';
+import isEmpty from 'lodash.isempty';
 
 export default function URL({
+  type = 'push',
   queryParams,
+  queryFunction,
   options = {
     skipNull: true,
     skipEmptyString: true,
@@ -11,17 +15,32 @@ export default function URL({
   },
 }) {
   const router = useRouter();
-  const { pathname } = router;
+  const isMounted = useRef(false);
+  const { query, pathname } = router;
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     const queryParamsSerialized = qs.stringify(queryParams, options);
 
-    router.replace(
+    router[
+      isMounted.current ? type : 'replace'
+    ](
       `${pathname}?${queryParamsSerialized}`,
       `${pathname}?${queryParamsSerialized}`,
       { shallow: true }
     );
   }, [queryParams]);
+
+  useDeepCompareEffect(() => {
+    if (isMounted.current && !isEmpty(query)) {
+      const queryKeys = Object.keys(queryParams);
+
+      queryKeys.forEach((k) => {
+        if (queryFunction) queryFunction({ key: k, value: query[k] || null });
+      });
+    } else {
+      isMounted.current = true;
+    }
+  }, [query]);
 
   return null;
 }

--- a/components/url/component.jsx
+++ b/components/url/component.jsx
@@ -36,7 +36,6 @@ export default function URL({
     if (isMounted.current && !isEmpty(query)) {
       const queryKeys = Object.keys(queryParams);
       const changedKeys = Object.keys(diff(query, prevQuery.current));
-      console.log(changedKeys, query, prevQuery.current);
 
       queryKeys.forEach((k) => {
         if (queryFunction && changedKeys.includes(k)) {

--- a/pages/explore/index.js
+++ b/pages/explore/index.js
@@ -39,7 +39,6 @@ export async function getServerSideProps(ctx) {
     dispatch(
       setIndicatorsActive(Array.isArray(indicator) ? indicator : [indicator])
     );
-    // TODO: dispatch(setIndicatorsCategory(ind.category.id));
   }
 
   return {
@@ -49,7 +48,14 @@ export async function getServerSideProps(ctx) {
   };
 }
 
-function ExplorePage({ locations, id, loaded, loading, urlParams }) {
+function ExplorePage({
+  locations,
+  id,
+  loaded,
+  loading,
+  urlParams,
+  queryFunction,
+}) {
   return (
     <Main>
       <GeometriesProvider />
@@ -74,7 +80,7 @@ function ExplorePage({ locations, id, loaded, loading, urlParams }) {
           )}
         </Media>
       </MediaContextProvider>
-      <Url queryParams={urlParams} />
+      <Url queryParams={urlParams} queryFunction={queryFunction} />
     </Main>
   );
 }
@@ -85,6 +91,7 @@ ExplorePage.propTypes = {
   loaded: PropTypes.bool,
   loading: PropTypes.bool,
   urlParams: PropTypes.shape({}),
+  queryFunction: PropTypes.func,
 };
 
 export default connect(
@@ -92,5 +99,26 @@ export default connect(
     ...selectGeometriesProps(state),
     urlParams: selectExploreUrlParams(state),
   }),
-  null
+  (dispatch) => ({
+    queryFunction: (param) => {
+      if (param.key === 'id') {
+        dispatch(setGeometryId(param.value || null));
+      }
+
+      if (param.key === 'indicator') {
+        if (!param.value) {
+          dispatch(setIndicatorsActive([]));
+        } else {
+          const { indicator } = qs.parse(`${param.key}=${param.value}`, {
+            arrayFormat: 'comma',
+          });
+          dispatch(
+            setIndicatorsActive(
+              Array.isArray(indicator) ? indicator : [indicator]
+            )
+          );
+        }
+      }
+    },
+  })
 )(ExplorePage);

--- a/providers/indicators/selectors.js
+++ b/providers/indicators/selectors.js
@@ -77,7 +77,18 @@ export const indicators = createSelector(
     if (!_data.length || _loading) return [];
 
     if (_category === '9999') return _relevant;
-    return _data.filter((d) => d.category.id === _category);
+    const indicatorsFromCategory = _data.filter(
+      (d) => d.category.id === _category
+    );
+    const parentIndicators = indicatorsFromCategory
+      .filter((ind) => !ind.parentId)
+      .map((parent) => ({
+        ...parent,
+        children: indicatorsFromCategory.filter(
+          (child) => +child.parentId === +parent.id
+        ),
+      }));
+    return parentIndicators;
   }
 );
 

--- a/services/geometries/index.js
+++ b/services/geometries/index.js
@@ -85,7 +85,7 @@ export const service = new GeometriesService();
 // ROUTES
 export function fetchGeometries(params, options = {}) {
   return service.request(
-    '/geometries?fields[geometries]=name,location-type,parent-id,bbox&page[size]=9999',
+    '/geometries?fields[geometries]=name,location-type,parent-id,bbox&page[size]=9999&filter[location-type]=county,state',
     options
   );
 }

--- a/utils/deepCompare.js
+++ b/utils/deepCompare.js
@@ -1,0 +1,16 @@
+import { useRef, useEffect } from 'react';
+import isEqual from 'lodash.isequal';
+
+function useDeepCompareMemoize(value) {
+  const ref = useRef();
+
+  if (!isEqual(value, ref.current)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+}
+
+export default function useDeepCompareEffect(callback, dependencies) {
+  useEffect(callback, useDeepCompareMemoize(dependencies));
+}

--- a/utils/diff.js
+++ b/utils/diff.js
@@ -1,0 +1,30 @@
+import isEqual from 'lodash.isequal';
+
+/**
+ * Deep diff between two object-likes
+ * @param  {Object} fromObject the original object
+ * @param  {Object} toObject   the updated object
+ * @return {Object}            a new object which represents the diff
+ */
+export function diff(fromObject, toObject) {
+  const changes = {};
+
+  Object.keys(fromObject).forEach((key) => {
+    if (!Object.keys(toObject).includes(key)) {
+      changes[key] = { from: fromObject[key] };
+    }
+  });
+
+  Object.entries(toObject).forEach(([key, to]) => {
+    if (!Object.keys(fromObject).includes(key)) {
+      changes[key] = { to };
+    } else {
+      const from = fromObject[key];
+      if (!isEqual(from, to)) {
+        changes[key] = { from, to };
+      }
+    }
+  });
+
+  return changes;
+}


### PR DESCRIPTION
Using [reFED implementation](https://github.com/Vizzuality/ReFED-frontend/pull/37/commits/18f81db234a92df6b9dc44a09778e777beb97b8d) with a simplification of [use-deep-compare-effect](https://github.com/kentcdodds/use-deep-compare-effect/blob/master/src/index.js) allows navigation in Explore using the browser back/forward buttons natively by pushing the url params to the router stack instead of replacing them.